### PR TITLE
Bug fix: Handling of Missing Species in NCBI Assembly Stats and GC Content Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ If you would like to contribute to this pipeline, please see the [contributing g
 If you use Spriggan for your analysis, please cite it using the following:
 
 ```
-A.C. Shockey, K. Florek, & E. Gunawan (2021). Spriggan (Version 1.6.1) [https://github.com/wslh-bio/spriggan/].
+A.C. Shockey, K. Florek, & E. Gunawan (2021). Spriggan (Version 1.6.2) [https://github.com/wslh-bio/spriggan/].
 ```
 
 This pipeline uses code and infrastructure developed and maintained by the [nf-core](https://nf-co.re) community, reused here under the [MIT license](https://github.com/nf-core/tools/blob/master/LICENSE).

--- a/bin/calculate_assembly_ratio.py
+++ b/bin/calculate_assembly_ratio.py
@@ -242,18 +242,10 @@ def search_ncbi_ratio_file(NCBI_ratio, genus, species, assembly_length, sample_n
 
                 return stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid
 
+    # If no match found, log and return None
     if not found:
-        logging.debug("If it was not found, write no matching found")
-
         logging.info(f"No match found for '{genus} {species}'")
-
-        with open(f"{sample_name}_Assembly_ratio_{NCBI_ratio_date}.txt", 'w') as outfile:
-            outfile.write(f"Sample: {sample_name}\nTax: {total_tax}\nNCBI_TAXID: {taxid}\nSpecies_StDev: NA\nIsolate_St.Devs: NA\nActual_length: {assembly_length}\nExpected_length: {expected_length}\nRatio Actual:Expected: -1\nRatio Expected:Actual: NA")
-
-        with open(f"{sample_name}_GC_content_{NCBI_ratio_date}.txt", 'w') as outfile:
-            outfile.write(f"Sample: {sample_name}\nTax: {total_tax}\nNCBI_TAXID: {taxid}\nSpecies_GC_StDev: No Match Found\nSpecies_GC_Min: No Match Found\nSpecies_GC_Max: No Match Found\nSpecies_GC_Mean: No Match Found\nSpecies_GC_Count: No Match Found\nSample_GC_Percent: No Match Found")
-
-        sys.exit(0)
+        return None
 
 def calculate_ratio(sample_name, NCBI_ratio_date, expected_length, total_tax, taxid, assembly_length, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdev):
 
@@ -337,21 +329,43 @@ def main(args=None):
             f"No NCBI assembly stats found for '{genus} {species}'in {NCBI_ratio_file}; proceeding with default values for sample '{sample_name}'."
         )
         # Assign placeholder values so output can still be written
-        taxid = None
-        stdev = None
-        stdevs = None
-        expected_length = None
-        # Assign 0.0 to numerical outputs
-        gc_stdev = gc_min = gc_max = gc_mean = gc_count = 0.0
+        taxid = "None"
+        stdev = "None"
+        stdevs = "None"
+        assembly_length_str = str(assembly_length) if assembly_length else "None"
+        expected_length = "None"
+        total_tax = "None"
+        ratio_a_e = "None"
+        ratio_e_a = "None"
+
+        # Write placeholder Assembly ratio file
+        with open(f"{sample_name}_Assembly_ratio_{NCBI_ratio_date}.txt", 'w') as outfile:
+            outfile.write(
+                f"Sample: {sample_name}\n"
+                f"Tax: {total_tax}\n"
+                f"NCBI_TAXID: {taxid}\n"
+                f"Species_St.Dev: {stdev}\n"
+                f"Isolate_St.Devs: {stdevs}\n"
+                f"Actual_length: {assembly_length_str}\n"
+                f"Expected_length: {expected_length}\n"
+                f"Ratio Actual:Expected: {ratio_a_e}\n"
+                f"Ratio Expected:Actual: {ratio_e_a}\n"
+            )
 
     else:
         stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid = result
 
-    #Calculating ratio 
-    ratio_a_e, ratio_e_a = calculate_ratio(sample_name, NCBI_ratio_file, expected_length, total_tax, taxid, assembly_length,gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdev)
+        # Calculate ratios
+        ratio_a_e, ratio_e_a = calculate_ratio(
+            sample_name, NCBI_ratio_date, expected_length, total_tax, taxid,
+            assembly_length, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdev
+        )
 
-    #Writing final output
-    write_output(sample_name, NCBI_ratio_date, total_tax, taxid, stdev, stdevs, assembly_length, expected_length, ratio_a_e, ratio_e_a)
+        # Write final output files
+        write_output(
+            sample_name, NCBI_ratio_date, total_tax, taxid, stdev, stdevs,
+            assembly_length, expected_length, ratio_a_e, ratio_e_a
+            )
     logging.info("Finished writing assembly ratio file.")
 
 if __name__ == "__main__":

--- a/bin/calculate_assembly_ratio.py
+++ b/bin/calculate_assembly_ratio.py
@@ -380,7 +380,7 @@ def main(args=None):
             sample_name, NCBI_ratio_date, total_tax, taxid, stdev, stdevs,
             assembly_length, expected_length, ratio_a_e, ratio_e_a
             )
-    logging.info("Finished writing assembly ratio file.")
+    logging.info("Finished writing assembly ratio file and GC content file.")
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bin/calculate_assembly_ratio.py
+++ b/bin/calculate_assembly_ratio.py
@@ -324,7 +324,28 @@ def main(args=None):
     total_tax, genus, species, found = process_NCBI_and_tax(args.taxonomy_to_compare, args.tax_file, sample_name)
 
     #Grabbing stats 
-    stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid = search_ncbi_ratio_file(NCBI_ratio_file, genus, species, assembly_length, sample_name, NCBI_ratio_date, total_tax, sample_gc_percent, found)
+    # stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid = search_ncbi_ratio_file(NCBI_ratio_file, genus, species, assembly_length, sample_name, NCBI_ratio_date, total_tax, sample_gc_percent, found)
+
+    result = search_ncbi_ratio_file(
+        NCBI_ratio_file, genus, species, assembly_length,
+        sample_name, NCBI_ratio_date, total_tax,
+        sample_gc_percent, found
+    )
+
+    if result is None:
+        logging.warning(
+            f"No NCBI assembly stats found for '{genus} {species}'in {NCBI_ratio_file}; proceeding with default values for sample '{sample_name}'."
+        )
+        # Assign placeholder values so output can still be written
+        taxid = None
+        stdev = None
+        stdevs = None
+        expected_length = None
+        # Assign 0.0 to numerical outputs
+        gc_stdev = gc_min = gc_max = gc_mean = gc_count = 0.0
+
+    else:
+        stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid = result
 
     #Calculating ratio 
     ratio_a_e, ratio_e_a = calculate_ratio(sample_name, NCBI_ratio_file, expected_length, total_tax, taxid, assembly_length,gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdev)

--- a/bin/calculate_assembly_ratio.py
+++ b/bin/calculate_assembly_ratio.py
@@ -352,6 +352,20 @@ def main(args=None):
                 f"Ratio Expected:Actual: {ratio_e_a}\n"
             )
 
+        # Write placeholder GC content file
+        with open(f"{sample_name}_GC_content_{NCBI_ratio_date}.txt", 'w') as outfile:
+            outfile.write(
+                f"Sample: {sample_name}\n"
+                f"Tax: {total_tax}\n"
+                f"NCBI_TAXID: {taxid}\n"
+                f"Species_GC_StDev: None\n"
+                f"Species_GC_Min: None\n"
+                f"Species_GC_Max: None\n"
+                f"Species_GC_Mean: None\n"
+                f"Species_GC_Count: None\n"
+                f"Sample_GC_Percent: None\n"
+            )
+
     else:
         stdev, gc_stdev, gc_min, gc_max, gc_mean, gc_count, stdevs, expected_length, taxid = result
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -173,7 +173,7 @@ manifest {
     description     = 'A pipeline used for assembly of bacterial whole genome sequence data and identification of antibiotic resistance genes.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=21.10.3'
-    version         = '1.6.1'
+    version         = '1.6.2'
     doi             = ''
 }
 


### PR DESCRIPTION
This update enhances the script’s robustness and output consistency when processing samples with species that are not present in the NCBI assembly stats database. Key changes include:

- Removed premature script exits (`sys.exit()`) inside the `search_ncbi_ratio_file()` function to allow graceful handling of missing data.

- Modified `search_ncbi_ratio_file()` to return `None` when no matching species data is found, rather than exiting or writing output.

- Centralized output file writing logic in `main()`, ensuring that an assembly ratio output file is always generated per sample

- For missing species, generates placeholder output files with consistent "None" values for all statistics, including GC content.

- Added placeholder GC content file generation for samples with missing species data to keep downstream workflows intact.